### PR TITLE
ci: add R CMD check workflow

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,3 @@
 ^README\.Rmd$
 ^LICENSE\.md$
+^\.github$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,37 @@
+name: R CMD check
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  R-CMD-check:
+    runs-on: ubuntu-latest
+    env:
+      NOT_CRAN: "false"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y castxml
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          error-on: '"error"'


### PR DESCRIPTION
## Summary

Add a lightweight GitHub Actions workflow so porter has a stable CI check on pull requests and pushes to `main`. The workflow is intentionally narrow for the first CI pass: it installs CastXML and runs the R package check path while keeping the existing network-heavy release download tests out of the required PR path.

Closes #4

## Changes

- Add an `R CMD check` workflow for pull requests, pushes to `main`, and manual dispatch.
- Install CastXML on the Ubuntu runner before setting up R dependencies.
- Use r-lib Actions for R setup, dependency installation, and package checking.
- Set the workflow to CRAN-like behavior so existing `skip_on_cran()` network tests are skipped while local CastXML compatibility tests still run.
- Exclude `.github` from the R package build.

## Out of scope

- A scheduled/manual workflow for full network-dependent checks against Kitware and GitHub release APIs.
- Multi-platform CI for macOS and Windows.