### PR TITLE
fix(port): support R header dynport generation

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -14,7 +14,7 @@ jobs:
   R-CMD-check:
     runs-on: ubuntu-latest
     env:
-      NOT_CRAN: "false"
+      NOT_CRAN: "true"
     steps:
       - uses: actions/checkout@v4
 

--- a/R/check.R
+++ b/R/check.R
@@ -12,8 +12,8 @@ port_check_field_package <- function(x, ...) {
         stop("'Package' field should only contain ASCII letters, numbers and dots.")
     }
 
-    if (nchar(x$value) < 2L) {
-        stop("'Package' field should be at least two character long.")
+    if (!nchar(x$value)) {
+        stop("'Package' field should not be empty.")
     }
 
     if (!grepl("^[a-zA-z]", x$value)) {

--- a/R/port.R
+++ b/R/port.R
@@ -77,10 +77,10 @@ port <- function(header, limit = TRUE, keep = FALSE, cflags = NULL, castxml = Sy
         pattern <- limit
     }
     data <- port_xml(out, dirs, pattern, clean = TRUE)
-    report <- attr(data, "report", exact = TRUE)
-    attr(data, "report") <- NULL
+    parsed <- pull_report(data)
+    data <- parsed$data
     report <- combine_reports(
-        report,
+        parsed$report,
         scan_castxml_function_like_macros(header, cflags, castxml, dirs, pattern)
     )
 
@@ -223,7 +223,9 @@ port_xml <- function(xml, dirs = NULL, pattern = NULL, clean = FALSE) {
     fields  <- proc_node_fields(xml)
     types   <- proc_node_types(xml)
     funs    <- proc_node_funs(xml)
-    enums   <- proc_node_enums(xml,   types)
+    enums   <- pull_report(proc_node_enums(xml, types, files))
+    report  <- enums$report
+    enums   <- enums$data
     structs <- proc_node_structs(xml, types, fields)
     unions  <- proc_node_unions(xml,  types, fields)
 
@@ -236,7 +238,7 @@ port_xml <- function(xml, dirs = NULL, pattern = NULL, clean = FALSE) {
     # find base types for all function arguments and return values
     funs <- proc_type_funs(types, funs)
 
-    report <- empty_report()
+    report <- combine_reports(report)
 
     variadic <- NULL
     if (!is.null(funs)) {
@@ -267,6 +269,15 @@ port_xml <- function(xml, dirs = NULL, pattern = NULL, clean = FALSE) {
     layout <- mark_unsupported_layouts(unions, "union", files)
     unions <- layout$data
     report <- combine_reports(report, layout$report)
+
+    drop_unnamed <- function(df) {
+        if (is.null(df)) return(NULL)
+        as_df(df[!is.na(df$name) & nzchar(df$name), , drop = FALSE])
+    }
+    enums <- drop_unnamed(enums)
+    structs <- drop_unnamed(structs)
+    unions <- drop_unnamed(unions)
+    funptrs <- drop_unnamed(funptrs)
 
     # only consider files in the same folder as the input header file
     if (!is.null(dirs)) {
@@ -313,6 +324,21 @@ port_xml <- function(xml, dirs = NULL, pattern = NULL, clean = FALSE) {
                 c(funs$file, variadic$file, enums$file, structs$file, unions$file, funptrs$file)), ]
         }
     }
+
+    filtered <- filter_rdyncall_output(
+        list(
+            Function = funs, Variadic = variadic, FuncPtr = funptrs,
+            Enum = enums, Struct = structs, Union = unions
+        ),
+        files
+    )
+    funs <- filtered$data$Function
+    variadic <- filtered$data$Variadic
+    funptrs <- filtered$data$FuncPtr
+    enums <- filtered$data$Enum
+    structs <- filtered$data$Struct
+    unions <- filtered$data$Union
+    report <- combine_reports(report, filtered$report)
 
     if (!is_flag(clean)) stop("Argument 'clean' should be either TRUE or FALSE.")
     if (clean) {
@@ -712,6 +738,7 @@ proc_node_funs <- function(xml) {
 correct_struct_names <- function(structs, types, fields = NULL) {
     # NOTE: It is possible that some enums/structs/unions have empty names
     #       in the XML. Should use Typedef to get the full names
+    structs$name[is.na(structs$name)] <- ""
     if (any(empty <- structs$name == "")) {
         # this is the gccxml output
         if (is.null(types$elaborated)) {
@@ -722,16 +749,11 @@ correct_struct_names <- function(structs, types, fields = NULL) {
         # The elaborated types should be used to find the actual typedefs
         } else {
             ind <- match(structs$id[empty], types$elaborated$type)
-            if (anyNA(ind)) {
-                stop(spaste(
-                    "Internal error: found struct(s) without a elaborated type ('%s').",
-                    .v = structs$id[empty][is.na(ind)], .vcoll = " "
-                ))
-            }
-            ids <- types$elaborated$id
+            ids <- rep(NA_character_, length(ind))
+            ids[!is.na(ind)] <- types$elaborated$id[ind[!is.na(ind)]]
         }
 
-        ind <- match(ids[ind], types$def$type)
+        ind <- match(ids, types$def$type)
         structs$name[which(empty)[!is.na(ind)]] <- types$def$name[ind[!is.na(ind)]]
 
         # check again and try to match using fields
@@ -752,18 +774,13 @@ correct_struct_names <- function(structs, types, fields = NULL) {
             structs$name[which(empty)[!is.na(ind)]] <- fields$name[ind[!is.na(ind)]]
         }
 
-        # check again and issue warnings if still no matched
-        if (any(empty <- structs$name == "")) {
-            warning(spaste(
-                "Failed to parse names for structs/unions: %s.",
-                .v = spaste("'%s'", .v = structs$id[empty], .rcoll = ", ")
-            ))
-        }
+        # Remaining empty names are anonymous internal types. Keep them unnamed;
+        # public dynport output filters them before writing.
     }
     structs
 }
 
-proc_node_enums <- function(xml, types) {
+proc_node_enums <- function(xml, types, files = NULL) {
     node_enums <- xml2::xml_find_all(xml, "Enumeration")
     enums <- node_attrs(node_enums,
         attrs = c("id", "name", "context", "size", "align", "file")
@@ -779,22 +796,35 @@ proc_node_enums <- function(xml, types) {
     enums$size <- bits_to_bytes(enums$size)
     enums$align <- bits_to_bytes(enums$align)
 
+    report <- empty_report()
     enum_vals <- node_attrs(node_enums, "EnumValue", c("name", "init"), df = FALSE)
     enums$values <- vector("list", nrow(enums))
     for (i in seq_len(nrow(enums))) {
         val <- .subset2(enum_vals, i)
         # check if init value is not an integer
-        init <- as.integer(val$init)
+        init <- suppressWarnings(as.integer(val$init))
         if (anyNA(init)) {
-            stop(spaste("Internal error: failed to convert initial values for",
-                "enum '%s' to integers: [%s=%s]", .vcoll = ", ",
-                .v = list(enums$name[[i]], val$name[is.na(init)], val$init[is.na(init)])
+            bad <- is.na(init)
+            file <- enums$file[[i]]
+            if (!is.null(files)) file <- files$name[match(file, files$id)]
+            report <- combine_reports(report, new_report(
+                "unsupported_enum_value", val$name[bad], file,
+                sprintf(
+                    "enum member value cannot be represented as an R integer and was not written: %s",
+                    val$init[bad]
+                )
             ))
+            keep <- !is.na(init)
+            val$name <- val$name[keep]
+            val$init <- val$init[keep]
+            init <- init[keep]
         }
         enums$values[[i]] <- df(name = val$name, init = init)
     }
 
-    enums[, c("id", "name", "values", "size", "align", "file")]
+    enums <- enums[, c("id", "name", "values", "size", "align", "file")]
+    attr(enums, "report") <- report
+    enums
 }
 
 proc_node_structs_unions <- function(xml, kind = c("struct", "union"), types, fields) {
@@ -819,14 +849,22 @@ proc_node_structs_unions <- function(xml, kind = c("struct", "union"), types, fi
 
     # get field member list
     members <- strsplit(structs$members, " ", fixed = TRUE)
+    ignored_members <- c(
+        xml2::xml_attr(xml2::xml_find_all(xml, "Unimplemented"), "id"),
+        xml2::xml_attr(xml2::xml_find_all(xml, "IndirectField"), "id")
+    )
+    ignored_members <- ignored_members[!is.na(ignored_members)]
 
     # cache for all structs and unions id/name
     # needed only when there are members that are another structs or unions
     structs_unions <- NULL
 
     for (i in seq_len(nrow(structs))) {
+        mem <- members[[i]]
+        mem <- mem[!mem %in% ignored_members]
+
         # if there is no members, remove member data of that struct
-        if (length(mem <- members[[i]]) == 1L && is.na(mem)) {
+        if (!length(mem) || (length(mem) == 1L && is.na(mem))) {
             structs$members[i] <- list(NULL)
             next
         }
@@ -1035,6 +1073,127 @@ format_array_type <- function(array) {
     len <- max - min + 1L
     len[is.na(len) | len < 1L] <- NA_integer_
     ifelse(is.na(len), "[]", sprintf("[%d]", len))
+}
+
+filter_rdyncall_output <- function(data, files = NULL) {
+    report <- empty_report()
+
+    file_names <- function(file) {
+        if (is.null(files) || is.null(file)) return(rep(NA_character_, length(file)))
+        out <- files$name[match(file, files$id)]
+        out[is.na(out)] <- NA_character_
+        out
+    }
+
+    valid_export_name <- function(name) {
+        !is.na(name) & nzchar(name) & name == make.names(name)
+    }
+
+    type_references_valid_names <- function(type) {
+        if (!inherits(type, "dynporttype")) return(TRUE)
+        named <- type$kind %in% c("enum", "struct", "union")
+        names <- gsub("^<(.*)>$", "\\1", type$type[named])
+        !any(!valid_export_name(names))
+    }
+
+    type_has_writable_signature <- function(type, empty = FALSE, array = FALSE) {
+        dyncall_sig(type, empty = empty, array = array)
+        type_references_valid_names(type)
+    }
+
+    filter_export_names <- function(df, field) {
+        if (is.null(df)) return(df)
+        keep <- valid_export_name(df$name)
+        if (any(!keep)) {
+            report <<- combine_reports(report, new_report(
+                "unsupported_export_name", df$name[!keep], file_names(df$file[!keep]),
+                sprintf("%s name is not a valid R export name and was not written", field)
+            ))
+        }
+        as_df(df[keep, , drop = FALSE])
+    }
+
+    filter_function_signatures <- function(df, field) {
+        if (is.null(df)) return(df)
+        keep <- vapply(seq_len(nrow(df)), function(i) {
+            ret <- df$returns[[i]]
+            if (!inherits(ret, "dynporttype") && !is.null(ret$type)) ret <- ret$type
+            args <- df$arguments[[i]]
+            arg_types <- if (!length(args)) list() else args$type
+
+            !inherits(try({
+                if (!type_has_writable_signature(ret, empty = TRUE)) stop("invalid type name")
+                ok <- vapply(arg_types, type_has_writable_signature, logical(1), empty = FALSE)
+                if (any(!ok)) stop("invalid type name")
+            }, silent = TRUE), "try-error")
+        }, logical(1))
+        if (any(!keep)) {
+            report <<- combine_reports(report, new_report(
+                "unsupported_signature", df$name[!keep], file_names(df$file[!keep]),
+                sprintf("%s signature cannot be written as a rdyncall dynport signature", field)
+            ))
+        }
+        as_df(df[keep, , drop = FALSE])
+    }
+
+    filter_aggregate_signatures <- function(df, field) {
+        if (is.null(df)) return(df)
+        keep <- vapply(seq_len(nrow(df)), function(i) {
+            mem <- df$members[[i]]
+            if (!length(mem$type)) return(TRUE)
+            !inherits(try({
+                ok <- vapply(
+                    mem$type, type_has_writable_signature, logical(1),
+                    empty = FALSE, array = TRUE
+                )
+                if (any(!ok)) stop("invalid type name")
+            }, silent = TRUE), "try-error")
+        }, logical(1))
+        if (any(!keep)) {
+            report <<- combine_reports(report, new_report(
+                "unsupported_signature", df$name[!keep], file_names(df$file[!keep]),
+                sprintf("%s member signature cannot be written as a rdyncall dynport signature", field)
+            ))
+        }
+        as_df(df[keep, , drop = FALSE])
+    }
+
+    filter_enum_members <- function(df) {
+        if (is.null(df)) return(df)
+        for (i in seq_len(nrow(df))) {
+            values <- df$values[[i]]
+            keep <- valid_export_name(values$name)
+            if (any(!keep)) {
+                report <<- combine_reports(report, new_report(
+                    "unsupported_export_name", values$name[!keep], file_names(df$file[[i]]),
+                    sprintf("enum member of '%s' is not a valid R export name and was not written", df$name[[i]])
+                ))
+                df$values[[i]] <- values[keep, , drop = FALSE]
+            }
+        }
+        df
+    }
+
+    for (field in c("Function", "Variadic", "FuncPtr")) {
+        data[[field]] <- filter_function_signatures(data[[field]], field)
+        data[[field]] <- filter_export_names(data[[field]], field)
+    }
+
+    for (field in c("Enum", "Struct", "Union")) {
+        data[[field]] <- filter_export_names(data[[field]], field)
+    }
+    for (field in c("Struct", "Union")) {
+        data[[field]] <- filter_aggregate_signatures(data[[field]], field)
+    }
+    data$Enum <- filter_enum_members(data$Enum)
+
+    list(data = data, report = report)
+}
+
+pull_report <- function(data) {
+    report <- attr(data, "report", exact = TRUE)
+    attr(data, "report") <- NULL
+    list(data = data, report = combine_reports(report))
 }
 
 empty_report <- function() {

--- a/R/port.R
+++ b/R/port.R
@@ -606,22 +606,37 @@ merge_all_types <- function(types, enums, structs, unions, fields) {
     }
 
     if (!is.null(types$func)) {
-        # all function types are function pointers
-        ind <- match(types$func$id, types$pointer$type)
+        types$all <- rbind.data.frame(types$all,
+            df(
+                id = types$func$id, name = "",
+                type = NA_character_, kind = "function"
+            )
+        )
 
-        # just in case
-        if (any(mis <- is.na(ind))) {
-            stop(spaste(
-                "Found function types not defined as pointers: [%s]",
-                .v = spaste("'%s'", .v = types$func[mis]),
-                .vcoll = ", "
-            ))
+        # Only function types directly referenced by a PointerType are written
+        # as FuncPtr entries. Function-type typedefs remain in types$all so
+        # chains such as PointerType -> Typedef -> FunctionType resolve to p.
+        ind <- match(types$func$id, types$pointer$type)
+        types$func <- types$func[!is.na(ind), , drop = FALSE]
+        ind <- ind[!is.na(ind)]
+
+        if (!nrow(types$func)) {
+            types$func <- NULL
+            return(types)
         }
 
         # there are only 2 possible ways that function pointers can appear:
         # a. in Typedef
         # b. as a member in Struct/Union
-        members <- do.call(rbind.data.frame, c(structs$members, unions$members))
+        members_list <- c(
+            if (!is.null(structs)) structs$members else NULL,
+            if (!is.null(unions)) unions$members else NULL
+        )
+        members <- if (length(members_list)) {
+            do.call(rbind.data.frame, members_list)
+        } else {
+            df(id = character(), name = character(), type = character())
+        }
         types_tmp <- df(
             type = c(types$def$type, members$type),
             name = c(types$def$name, members$name),
@@ -642,13 +657,6 @@ merge_all_types <- function(types, enums, structs, unions, fields) {
                 .v = spaste("'%s'", .v = types$func$id[empty], .rcoll = ", ")
             ))
         }
-
-        types$all <- rbind.data.frame(types$all,
-            df(
-                id = types$func$id, name = types$func$name,
-                type = NA_character_, kind = "function"
-            )
-        )
 
         # process argument and return types
         types$func <- proc_type_funs(types, types$func)[

--- a/R/restful.R
+++ b/R/restful.R
@@ -72,7 +72,7 @@ github_token <- function(token = NULL) {
         token <- if (length(token)) token[1L] else NULL
     }
 
-    if (!nchar(token)) return(NULL)
+    if (is.null(token) || !nchar(token)) return(NULL)
 
     if (!grepl("^gh[pousr]_[A-Za-z0-9_]{36,251}$", token) &&
         !grepl("[[:xdigit:]]{40}", token)) {

--- a/tests/testthat/test-field.R
+++ b/tests/testthat/test-field.R
@@ -29,6 +29,7 @@ test_that("port_set() works", {
     expect_s3_class(p <- port(header_sdl), "dynport")
 
     expect_error(port_set(p, "Package", ".SDL2"))
+    expect_s3_class(port_set(p, "Package", "R"), "dynport")
     expect_s3_class(p <- port_set(p, "Package", "SDL2"), "dynport")
     expect_equal(port_get(p, "Package"), "SDL2")
     expect_equal(port_get(p, c("Package", "Version")), list(Package = "SDL2", Version = NULL))

--- a/tests/testthat/test-port.R
+++ b/tests/testthat/test-port.R
@@ -77,10 +77,10 @@ test_that("port() works", {
     expect_named(p$Struct$value,   c("name", "members", "size", "align"))
     expect_named(p$Union$value,    c("name", "members", "size", "align"))
 
-    expect_equal(nrow(p$Function$value) + if (is.null(p$Variadic$value)) 0L else nrow(p$Variadic$value), 855L)
+    expect_equal(nrow(p$Function$value) + if (is.null(p$Variadic$value)) 0L else nrow(p$Variadic$value), 708L)
     expect_gt(nrow(p$FuncPtr$value),  0L)
     expect_equal(nrow(p$Enum$value),     55L)
-    expect_equal(nrow(p$Struct$value),   92L)
-    expect_equal(nrow(p$Union$value),    5L)
+    expect_equal(nrow(p$Struct$value),   76L)
+    expect_equal(nrow(p$Union$value),    3L)
     expect_equal(length(p$File$value),   46L)
 })

--- a/tests/testthat/test-rdyncall-compat.R
+++ b/tests/testthat/test-rdyncall-compat.R
@@ -7,8 +7,13 @@ test_that("rdyncall-compatible ABI details are preserved", {
         "int fixed(int x);",
         "int vf(const char *fmt, ...);",
         "typedef int (*callback_t)(int x, ...);",
+        "long double unsupported_long_double(void);",
+        "struct _Hidden { int x; };",
+        "enum Boolish { TRUE = 1, PORTER_OK = 2 };",
+        "enum TooWide { TOO_LOW = -2147483648, TOO_WIDE_OK = 1 };",
         "struct Plain { int a[3]; unsigned b:5; unsigned :0; unsigned c:7; };",
-        "struct __attribute__((packed, aligned(8))) PackedAligned { char c; double d; };"
+        "struct __attribute__((packed, aligned(8))) PackedAligned { char c; double d; };",
+        "struct HasAnon { int tag; union { int i; double d; }; };"
     ), header)
 
     p <- port(header, limit = TRUE)
@@ -16,10 +21,19 @@ test_that("rdyncall-compatible ABI details are preserved", {
     expect_equal(p$Function$value$name, "fixed")
     expect_false(any(p$Function$value$ellipsis))
     expect_equal(p$Variadic$value$name, "vf")
+    expect_false("unsupported_long_double" %in% p$Function$value$name)
+    expect_false("_Hidden" %in% p$Struct$value$name)
+    expect_false("HasAnon" %in% p$Struct$value$name)
+    expect_equal(p$Enum$value$values[[which(p$Enum$value$name == "Boolish")]]$name, "PORTER_OK")
 
     report <- port_report(p)
     expect_true(any(report$kind == "unsupported_macro" & report$name == "MACRO_FN"))
     expect_true(any(report$kind == "unsupported_variadic_funcptr" & report$name == "callback_t"))
+    expect_true(any(report$kind == "unsupported_signature" & report$name == "unsupported_long_double"))
+    expect_true(any(report$kind == "unsupported_signature" & report$name == "HasAnon"))
+    expect_true(any(report$kind == "unsupported_export_name" & report$name == "_Hidden"))
+    expect_true(any(report$kind == "unsupported_export_name" & report$name == "TRUE"))
+    expect_true(any(report$kind == "unsupported_enum_value" & report$name == "TOO_LOW"))
 
     file <- tempfile(fileext = ".dynport")
     suppressWarnings(port_write(p, file))
@@ -87,4 +101,73 @@ test_that("macro diagnostics report CastXML preprocessor failures", {
     expect_equal(report$kind, c("macro_scan_failed", "macro_scan_failed"))
     expect_equal(report$name, c("-dD", "-dM"))
     expect_true(all(is.na(report$line)))
+})
+
+test_that("R headers can be converted despite anonymous CastXML members", {
+    skip_if(Sys.which("castxml") == "", "CastXML is not available")
+
+    inc <- file.path(R.home(), "include")
+    headers <- file.path(inc, c("R.h", "Rinternals.h"))
+    skip_if_not(all(file.exists(headers)), "R headers are not available")
+
+    header <- tempfile(fileext = ".h")
+    writeLines(c("#include <R.h>", "#include <Rinternals.h>"), header)
+    on.exit(unlink(header), add = TRUE)
+
+    cflags <- paste0("-I", inc)
+    if (identical(Sys.info()[["sysname"]], "Darwin") && nzchar(Sys.which("xcrun"))) {
+        sdk <- try(system2("xcrun", "--show-sdk-path", stdout = TRUE), silent = TRUE)
+        if (!inherits(sdk, "try-error") && length(sdk) && nzchar(sdk[[1L]])) {
+            cflags <- c(cflags, "-isysroot", sdk[[1L]])
+        }
+    }
+
+    p <- suppressWarnings(port(header, limit = inc, cflags = cflags))
+
+    expect_true("Function" %in% port_fields(p))
+    expect_true("Variadic" %in% port_fields(p))
+    expect_true("R_IsNA" %in% port_get(p, "Function")$name)
+    expect_true("Rprintf" %in% port_get(p, "Variadic")$name)
+    expect_true("SEXPREC" %in% port_get(p, "Struct")$name)
+    expect_true(any(port_report(p)$kind == "unsupported_macro"))
+
+    p <- port_set(
+        p,
+        Package = "R",
+        Version = as.character(getRversion()),
+        Library = "R"
+    )
+    file <- tempfile(fileext = ".dynport")
+    suppressWarnings(port_write(p, file))
+    expect_true(file.exists(file))
+
+    text <- readLines(file, warn = FALSE)
+    expect_false(any(grepl("R_allocLD", text, fixed = TRUE)))
+    expect_false(any(grepl("_DllInfo", text, fixed = TRUE)))
+    expect_false(any(grepl("FALSE=", text, fixed = TRUE)))
+    expect_false(any(grepl("TRUE=", text, fixed = TRUE)))
+
+    report <- port_report(p)
+    expect_true(any(report$kind == "unsupported_export_name"))
+
+    if (requireNamespace("rdyncall", quietly = TRUE)) {
+        supports_current_dynport <- try({
+            probe <- tempfile(fileext = ".dynport")
+            writeLines(c(
+                "Package: Probe",
+                "Library: c",
+                "Variadic:",
+                "    printf(Z)i fmt;"
+            ), probe)
+            rdyncall:::dynport_read(probe)
+        }, silent = TRUE)
+
+        if (!inherits(supports_current_dynport, "try-error")) {
+            parsed <- rdyncall:::dynport_read(file)
+            expect_equal(as.character(parsed$Package), "R")
+            expect_true("R_IsNA" %in% names(parsed$Function))
+            expect_true("Rprintf" %in% names(parsed$Variadic))
+            expect_true("SEXPREC" %in% names(parsed$Struct))
+        }
+    }
 })

--- a/tests/testthat/test-rdyncall-compat.R
+++ b/tests/testthat/test-rdyncall-compat.R
@@ -103,6 +103,30 @@ test_that("macro diagnostics report CastXML preprocessor failures", {
     expect_true(all(is.na(report$line)))
 })
 
+test_that("function type typedef pointers are written as pointers", {
+    skip_if(Sys.which("castxml") == "", "CastXML is not available")
+
+    header <- tempfile(fileext = ".h")
+    writeLines(c(
+        "typedef int bare_fn_t(int x);",
+        "struct Holder { bare_fn_t *cb; };",
+        "int fixed(int x);"
+    ), header)
+
+    p <- port(header, limit = TRUE)
+
+    expect_equal(port_get(p, "Function")$name, "fixed")
+    expect_false("bare_fn_t" %in% port_get(p, "FuncPtr")$name)
+    expect_equal(port_get(p, "Struct")$name, "Holder")
+
+    p <- port_set(p, Package = "T", Version = "1.0", Library = "T")
+    file <- tempfile(fileext = ".dynport")
+    suppressWarnings(port_write(p, file))
+    txt <- paste(readLines(file), collapse = "\n")
+
+    expect_match(txt, "Holder\\{p\\}cb;", fixed = FALSE)
+})
+
 test_that("R headers can be converted despite anonymous CastXML members", {
     skip_if(Sys.which("castxml") == "", "CastXML is not available")
 

--- a/tests/testthat/test-restful.R
+++ b/tests/testthat/test-restful.R
@@ -1,3 +1,22 @@
+test_that("github_token() handles missing tokens", {
+    vars <- c("GITHUB_PAT", "GITHUB_TOKEN", "GH_TOKEN")
+    old <- Sys.getenv(vars, unset = NA_character_)
+    on.exit({
+        for (var in vars) {
+            if (is.na(old[[var]])) {
+                Sys.unsetenv(var)
+            } else {
+                do.call(Sys.setenv, as.list(structure(old[[var]], names = var)))
+            }
+        }
+    }, add = TRUE)
+
+    Sys.unsetenv(vars)
+
+    expect_null(github_token())
+    expect_null(github_token(""))
+})
+
 test_that("github_release_latest() works", {
     skip_on_cran()
     rel <- github_release_latest("libsdl-org/SDL")


### PR DESCRIPTION
## Summary

This makes porter handle R's public headers as a first-class CastXML input for rdyncall-compatible dynport generation. The goal is for `porter::port()` and `port_write()` to produce a usable DCF dynport from `<R.h>` and `<Rinternals.h>` without relying on a downstream rdyncall script to filter unsafe entries.

Closes #6

## Changes

- Allow one-character non-empty `Package` values, including the natural `Package: R`.
- Keep unresolved anonymous CastXML struct/union/enum nodes as unnamed internal types instead of failing during name correction.
- Ignore CastXML non-field members such as `Unimplemented` and `IndirectField` while parsing aggregate members.
- Preserve function-type typedefs in the type graph so Linux header patterns like `PointerType -> Typedef -> FunctionType` resolve as pointer signatures.
- Drop enum members whose values cannot be represented as R integers and report them through `port_report()`.
- Filter rdyncall output entries that cannot be written as valid signatures or exported names, with diagnostics for unsupported signatures, export names, and enum values.
- Allow missing GitHub token environment variables to fall back to anonymous GitHub API requests.
- Update SDL smoke expectations for the rdyncall-compatible filtered output.
- Run GitHub Actions checks with `NOT_CRAN=true` so CI exercises the non-CRAN CastXML tests.
- Extend rdyncall compatibility tests with unsafe signatures, invalid export names, anonymous aggregate handling, function-type typedef pointers, and an R header smoke using `<R.h>` and `<Rinternals.h>`.

## Out of scope

- This does not add `R.dynport` to rdyncall.
- This does not generate callable entries for function-like macros.
- This does not change rdyncall parser behavior.
