### PR TITLE
fix: add macOS SDK flags for CastXML

### DIFF
--- a/R/port.R
+++ b/R/port.R
@@ -50,6 +50,7 @@ port <- function(header, limit = TRUE, keep = FALSE, cflags = NULL, castxml = Sy
     if (!is_flag(keep)) {
         stop("Argument 'keep' should be either TRUE or FALSE.")
     }
+    cflags <- normalize_castxml_cflags(cflags)
 
     castxml <- normalizePath(castxml, mustWork = TRUE)
     out <- tempfile("porter-", fileext = ".xml")
@@ -100,6 +101,30 @@ port <- function(header, limit = TRUE, keep = FALSE, cflags = NULL, castxml = Sy
     out <- structure(l, class = "dynport")
     attr(out, "report") <- report
     out
+}
+
+normalize_castxml_cflags <- function(cflags,
+                                    sysname = Sys.info()[["sysname"]],
+                                    sdkroot = Sys.getenv("SDKROOT", unset = ""),
+                                    xcrun = Sys.which("xcrun"),
+                                    xcrun_sdk = NULL) {
+    if (!identical(sysname, "Darwin")) return(cflags)
+    if (length(cflags) && any(startsWith(cflags, "-isysroot"))) return(cflags)
+
+    if (nzchar(sdkroot) && dir.exists(sdkroot)) {
+        return(c(cflags, "-isysroot", normalizePath(sdkroot, mustWork = TRUE)))
+    }
+
+    if (!nzchar(xcrun)) return(cflags)
+    if (is.null(xcrun_sdk)) {
+        xcrun_sdk <- try(system2(xcrun, "--show-sdk-path", stdout = TRUE), silent = TRUE)
+    }
+    if (inherits(xcrun_sdk, "try-error") || !length(xcrun_sdk) || !nzchar(xcrun_sdk[[1L]])) {
+        return(cflags)
+    }
+    if (!dir.exists(xcrun_sdk[[1L]])) return(cflags)
+
+    c(cflags, "-isysroot", normalizePath(xcrun_sdk[[1L]], mustWork = TRUE))
 }
 
 #' Inspect diagnostics recorded while generating a dynport

--- a/tests/testthat/test-port.R
+++ b/tests/testthat/test-port.R
@@ -84,3 +84,40 @@ test_that("port() works", {
     expect_equal(nrow(p$Union$value),    3L)
     expect_equal(length(p$File$value),   46L)
 })
+
+test_that("normalize_castxml_cflags() adds macOS SDK only when needed", {
+    cflags <- "-I/include"
+    sdkroot <- tempfile("sdkroot")
+    xcrun_sdk <- tempfile("xcrun-sdk")
+    dir.create(sdkroot)
+    dir.create(xcrun_sdk)
+
+    expect_identical(
+        normalize_castxml_cflags(cflags, sysname = "Linux"),
+        cflags
+    )
+    expect_identical(
+        normalize_castxml_cflags(NULL, sysname = "Darwin", sdkroot = "", xcrun = "", xcrun_sdk = xcrun_sdk),
+        NULL
+    )
+    expect_identical(
+        normalize_castxml_cflags(c(cflags, "-isysroot", sdkroot), sysname = "Darwin", sdkroot = xcrun_sdk),
+        c(cflags, "-isysroot", sdkroot)
+    )
+    expect_identical(
+        normalize_castxml_cflags(c(cflags, paste0("-isysroot", sdkroot)), sysname = "Darwin", sdkroot = xcrun_sdk),
+        c(cflags, paste0("-isysroot", sdkroot))
+    )
+    expect_identical(
+        normalize_castxml_cflags(cflags, sysname = "Darwin", sdkroot = sdkroot, xcrun = ""),
+        c(cflags, "-isysroot", normalizePath(sdkroot, mustWork = TRUE))
+    )
+    expect_identical(
+        normalize_castxml_cflags(cflags, sysname = "Darwin", sdkroot = "", xcrun = "xcrun", xcrun_sdk = xcrun_sdk),
+        c(cflags, "-isysroot", normalizePath(xcrun_sdk, mustWork = TRUE))
+    )
+    expect_identical(
+        normalize_castxml_cflags(cflags, sysname = "Darwin", sdkroot = "", xcrun = "", xcrun_sdk = xcrun_sdk),
+        cflags
+    )
+})

--- a/tests/testthat/test-rdyncall-compat.R
+++ b/tests/testthat/test-rdyncall-compat.R
@@ -145,15 +145,7 @@ test_that("R headers can be converted despite anonymous CastXML members", {
     writeLines(c("#include <R.h>", "#include <Rinternals.h>"), header)
     on.exit(unlink(header), add = TRUE)
 
-    cflags <- paste0("-I", inc)
-    if (identical(Sys.info()[["sysname"]], "Darwin") && nzchar(Sys.which("xcrun"))) {
-        sdk <- try(system2("xcrun", "--show-sdk-path", stdout = TRUE), silent = TRUE)
-        if (!inherits(sdk, "try-error") && length(sdk) && nzchar(sdk[[1L]])) {
-            cflags <- c(cflags, "-isysroot", sdk[[1L]])
-        }
-    }
-
-    p <- suppressWarnings(port(header, limit = inc, cflags = cflags))
+    p <- suppressWarnings(port(header, limit = inc, cflags = paste0("-I", inc)))
 
     expect_true("Function" %in% port_fields(p))
     expect_true("Variadic" %in% port_fields(p))


### PR DESCRIPTION
## Summary
Automatically add the active macOS SDK root to CastXML invocations when callers have not supplied an explicit `-isysroot`. This keeps CastXML XML generation and macro preprocessor diagnostics on the same compiler flag set.

## Changes
- Normalize `cflags` once in `port()` before running CastXML.
- Prefer an existing caller-provided `-isysroot`, then `SDKROOT`, then `xcrun --show-sdk-path` on macOS.
- Let the R header compatibility smoke rely on `port()` for SDK discovery instead of duplicating it in the test.

## Out of scope
- No new public `port()` argument.
- No changes to dynport filtering or rdyncall runtime behavior.