### PR TITLE
ci: expand R CMD check platforms

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -12,16 +12,43 @@ permissions:
 
 jobs:
   R-CMD-check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     env:
       NOT_CRAN: "true"
     steps:
       - uses: actions/checkout@v4
 
       - name: Install system dependencies
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y castxml
+
+      - name: Install system dependencies
+        if: runner.os == 'macOS'
+        run: brew install castxml
+
+      - name: Configure macOS SDK
+        if: runner.os == 'macOS'
+        run: |
+          sdk="$(xcrun --show-sdk-path)"
+          echo "SDKROOT=$sdk" >> "$GITHUB_ENV"
+          echo "CPATH=$sdk/usr/include" >> "$GITHUB_ENV"
+          echo "C_INCLUDE_PATH=$sdk/usr/include" >> "$GITHUB_ENV"
+          echo "CPLUS_INCLUDE_PATH=$sdk/usr/include" >> "$GITHUB_ENV"
+
+      - name: Install system dependencies
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
+          irm get.scoop.sh | iex
+          scoop install castxml
+          "$env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
## Summary
Expand porter’s R CMD check workflow beyond Ubuntu so platform-specific CastXML discovery and header parsing are exercised on the operating systems users are likely to use.

## Changes
- Run the existing R CMD check job on Ubuntu, macOS, and Windows.
- Install CastXML through the native package path for each runner.
- Configure the macOS SDK environment before checks so CastXML can parse system headers reliably.
- Keep `NOT_CRAN=true` so the package’s non-CRAN local compatibility checks run in CI.

## Out of scope
- Removing bundled network installer code.
- License metadata/year updates.

This PR is stacked on `refactor/remove-bundled-network-installers` and should be retargeted to `main` after that branch lands.
