### PR TITLE
fix: support bool and signed char signatures

### DIFF
--- a/R/port.R
+++ b/R/port.R
@@ -298,6 +298,7 @@ port_xml <- function(xml, dirs = NULL, pattern = NULL, clean = FALSE) {
                 Struct = NULL, Union = NULL, File = NULL
             ))
         } else {
+            report <- filter_report_by_dirs(report, dirs)
             subset_by_file <- function(df, files) {
                 if (!is.null(df)) as_df(df[df$file %in% files, ])
             }
@@ -1097,25 +1098,14 @@ filter_rdyncall_output <- function(data, files = NULL) {
         out
     }
 
-    valid_export_name <- function(name) {
-        !is.na(name) & nzchar(name) & name == make.names(name)
-    }
-
-    type_references_valid_names <- function(type) {
-        if (!inherits(type, "dynporttype")) return(TRUE)
-        named <- type$kind %in% c("enum", "struct", "union")
-        names <- gsub("^<(.*)>$", "\\1", type$type[named])
-        !any(!valid_export_name(names))
-    }
-
     type_has_writable_signature <- function(type, empty = FALSE, array = FALSE) {
-        dyncall_sig(type, empty = empty, array = array)
-        type_references_valid_names(type)
+        sig <- dyncall_sig(type, empty = empty, array = array)
+        signature_references_valid_names(sig)
     }
 
     filter_export_names <- function(df, field) {
         if (is.null(df)) return(df)
-        keep <- valid_export_name(df$name)
+        keep <- valid_dynport_name(df$name)
         if (any(!keep)) {
             report <<- combine_reports(report, new_report(
                 "unsupported_export_name", df$name[!keep], file_names(df$file[!keep]),
@@ -1174,7 +1164,7 @@ filter_rdyncall_output <- function(data, files = NULL) {
         if (is.null(df)) return(df)
         for (i in seq_len(nrow(df))) {
             values <- df$values[[i]]
-            keep <- valid_export_name(values$name)
+            keep <- valid_dynport_name(values$name)
             if (any(!keep)) {
                 report <<- combine_reports(report, new_report(
                     "unsupported_export_name", values$name[!keep], file_names(df$file[[i]]),
@@ -1200,6 +1190,21 @@ filter_rdyncall_output <- function(data, files = NULL) {
     data$Enum <- filter_enum_members(data$Enum)
 
     list(data = data, report = report)
+}
+
+filter_report_by_dirs <- function(report, dirs) {
+    if (is.null(report) || !nrow(report) || is.null(dirs)) return(report)
+
+    dirs <- normalizePath(dirs, mustWork = FALSE)
+    files <- report$file
+    has_real_file <- !is.na(files) & nzchar(files) & file.exists(files)
+    keep <- !has_real_file
+    paths <- normalizePath(dirname(files[has_real_file]), mustWork = FALSE)
+    in_scope <- logical(length(paths))
+    for (d in dirs) in_scope <- is_parent_dir(d, paths) | in_scope
+    keep[has_real_file] <- in_scope
+
+    report[keep, , drop = FALSE]
 }
 
 pull_report <- function(data) {
@@ -1377,15 +1382,16 @@ mark_unsupported_layouts <- function(df, kind, files) {
 
     if (!any(unsupported)) return(list(data = df, report = empty_report()))
 
+    named <- !is.na(df$name) & nzchar(df$name)
     report <- combine_reports(
         new_report(
-            "unsupported_type", df$name[unsupported_type],
-            files$name[match(df$file[unsupported_type], files$id)],
+            "unsupported_type", df$name[unsupported_type & named],
+            files$name[match(df$file[unsupported_type & named], files$id)],
             "aggregate member type cannot be written as a rdyncall signature; emitted as opaque"
         ),
         new_report(
-            "unsupported_layout", df$name[unsupported_layout & !unsupported_type],
-            files$name[match(df$file[unsupported_layout & !unsupported_type], files$id)],
+            "unsupported_layout", df$name[unsupported_layout & !unsupported_type & named],
+            files$name[match(df$file[unsupported_layout & !unsupported_type & named], files$id)],
             "aggregate layout cannot be expressed with rdyncall layout directives; emitted as opaque"
         )
     )

--- a/R/signature.R
+++ b/R/signature.R
@@ -19,6 +19,29 @@ BASETYPE_MAP <- c(
     "v" = "void"
 )
 
+valid_dynport_name <- function(name) {
+    !is.na(name) & nzchar(name) & name == make.names(name)
+}
+
+format_type_chain <- function(type) {
+    paste(sprintf("%s:%s", type$kind, type$type), collapse = " -> ")
+}
+
+signature_type_references <- function(sig) {
+    # Typed pointers may refer to opaque C tags that are not valid R object
+    # names, such as *_SDL_Joystick or *__sFILE. These are safe as pointer-only
+    # references, so only validate by-value references in the remaining text.
+    sig <- gsub("\\*<[^>]+>", "", sig, perl = TRUE)
+    refs <- regmatches(sig, gregexpr("<[^>]+>", sig, perl = TRUE))[[1L]]
+    if (!length(refs) || identical(refs, character(0))) return(character())
+    unique(sub("^<(.+)>$", "\\1", refs))
+}
+
+signature_references_valid_names <- function(sig) {
+    refs <- signature_type_references(sig)
+    !length(refs) || all(valid_dynport_name(refs))
+}
+
 drop_array_types <- function(type) {
     keep <- type$kind != "array"
     type$type <- type$type[keep]
@@ -41,48 +64,32 @@ dyncall_sig <- function(type, empty = FALSE, array = FALSE) {
         return(paste0(dyncall_sig(drop_array_types(type), empty, FALSE), array_suffix(type)))
     }
 
+    pointer_count <- sum(type$kind == "pointer")
+
     # If ends up with base type, then directly convert
     if (type$kind[len] == "base") {
-        # the simplest case
-        if (len == 1L) {
-            bt <- names(BASETYPE_MAP)[match(type$type, BASETYPE_MAP)]
-            if (is.na(bt)) {
-                stop(spaste("Internal error: unsupported base type found ('%s').", .v = type$type))
-            }
-            return(bt)
+        bt <- names(BASETYPE_MAP)[match(type$type[[len]], BASETYPE_MAP)]
+        if (is.na(bt)) {
+            stop(spaste("Internal error: unsupported base type found ('%s').", .v = type$type[[len]]))
         }
+
+        # the simplest case
+        if (len == 1L) return(bt)
+
+        if (pointer_count >= 2L) return("p")
 
         # pointer of a base type
-        if (len == 2L) {
-            bt <- names(BASETYPE_MAP)[match(type$type[[len]], BASETYPE_MAP)]
-            if (is.na(bt)) {
-                stop(spaste("Internal error: unknown base type found ('%s').", .v = type$type[[len]]))
-            }
-
+        if (pointer_count == 1L) {
             # *void
-            if (type$type[[1L]] == "*") {
-                if (bt == "v") return("p") else return(paste0("*", bt))
-            # const int, etc.
-            } else if (type$type[[1L]] == "const") {
-                return(bt)
-            } else if (type$kind[[1L]] == "array") {
-                return("p")
-            }
-        }
-
-        tp <- sort(type$type)
-
-        if (len == 3L) {
+            if (bt == "v") return("p")
             # const char *
-            if (identical(tp, c("*", "char", "const"))) {
-                return("Z") # string
-            } else if (tp[[1L]] == "*") {
-                return("p") # pointer
-            }
+            if (bt == "c" && "const" %in% type$type) return("Z")
+            if (len == 2L && type$type[[1L]] == "*") return(paste0("*", bt))
+            return("p")
         }
 
-        # const char **, return as pointer
-        if (len == 4L && tp[[1L]] == "*") return("p") # pointer
+        # const int, etc.
+        if (all(type$type[-len] == "const")) return(bt)
     }
 
     if (!(type$kind[len] %in% c("enum", "struct", "union", "function"))) {
@@ -94,7 +101,7 @@ dyncall_sig <- function(type, empty = FALSE, array = FALSE) {
 
     # NOTE: only support function pointer
     if (type$kind[len] == "function") {
-        if (any(!type$type[-len] %in% c("*", "[]", "const"))) {
+        if (any(!type$kind[-len] %in% c("pointer", "array", "cvqualified"))) {
             stop(spaste(
                 "Internal error: found 'function'",
                 "with an invalid qualifier ('%s'['%s']).",
@@ -106,13 +113,28 @@ dyncall_sig <- function(type, empty = FALSE, array = FALSE) {
     }
 
     # handle enums/structs/unions
+    target <- type$type[[len]]
+    target_name <- sub("^<(.*)>$", "\\1", target)
+    target_valid <- valid_dynport_name(target_name)
+    if (pointer_count >= 2L) return("p")
+    if (pointer_count == 1L) {
+        if (!nzchar(target_name)) return("p")
+        if (all(type$kind[-len] %in% c("pointer", "cvqualified"))) return(paste0("*", target))
+    }
+    if (!target_valid) {
+        stop(spaste(
+            "Internal error: found enum/struct/union with an invalid type name ('%s').",
+            .v = target
+        ))
+    }
+
     if (len == 1L) {
-        type$type
+        target
     } else if (len == 2L) {
         if (type$type[[1L]] == "const") {
-            type$type[[len]]
+            target
         } else if (type$type[[1L]] == "*" || type$kind[[1L]] == "array") {
-            paste0("*", type$type[[len]])
+            paste0("*", target)
         } else {
             stop(spaste(
                 "Internal error: found enum/struct/union",
@@ -122,7 +144,7 @@ dyncall_sig <- function(type, empty = FALSE, array = FALSE) {
         }
     } else if (len == 3L) {
         if (identical(sort(type$type[-len]), c("*", "const"))) {
-            paste0("*", type$type[len])
+            paste0("*", target)
         } else if (identical(type$type[-len], c("*", "*"))) {
             "p"
         } else {
@@ -135,7 +157,7 @@ dyncall_sig <- function(type, empty = FALSE, array = FALSE) {
     } else {
         stop(spaste(
             "Internal error: failed to detect signature ('%s')",
-            .v = list(type$type, type$kind), .vcoll = " "
+            .v = format_type_chain(type)
         ))
     }
 }
@@ -244,7 +266,8 @@ signature_type_info <- function(sig) {
 member_has_unsupported_signature <- function(mem) {
     if (!length(mem$type)) return(FALSE)
     any(vapply(mem$type, function(type) {
-        is.na(tryCatch(dyncall_sig(type, FALSE, array = TRUE), error = function(e) NA_character_))
+        sig <- tryCatch(dyncall_sig(type, FALSE, array = TRUE), error = function(e) NA_character_)
+        is.na(sig) || !signature_references_valid_names(sig)
     }, logical(1)))
 }
 

--- a/R/signature.R
+++ b/R/signature.R
@@ -1,6 +1,8 @@
 BASETYPE_MAP <- c(
     "B" = "_Bool",
+    "B" = "bool",
     "c" = "char",
+    "c" = "signed char",
     "C" = "unsigned char",
     "s" = "short int",
     "S" = "short unsigned int",

--- a/tests/testthat/test-rdyncall-compat.R
+++ b/tests/testthat/test-rdyncall-compat.R
@@ -134,6 +134,32 @@ test_that("function type typedef pointers are written as pointers", {
     expect_match(txt, "Holder\\{p\\}cb;", fixed = FALSE)
 })
 
+test_that("CastXML bool and signed char fundamental types are supported", {
+    skip_if_no_castxml()
+
+    header <- tempfile(fileext = ".h")
+    writeLines(c(
+        "#include <stdbool.h>",
+        "typedef signed char Sint8;",
+        "bool sdl_bool(void);",
+        "bool sdl_sint8(Sint8 value, Sint8 *out);"
+    ), header)
+
+    p <- port(header, limit = TRUE)
+    functions <- port_get(p, "Function")
+
+    expect_true(all(c("sdl_bool", "sdl_sint8") %in% functions$name))
+    expect_false(any(port_report(p, "unsupported_signature")$name %in% functions$name))
+
+    p <- port_set(p, Package = "T", Version = "1.0", Library = "T")
+    file <- tempfile(fileext = ".dynport")
+    suppressWarnings(port_write(p, file))
+    txt <- paste(readLines(file), collapse = "\n")
+
+    expect_match(txt, "sdl_bool\\(\\)B;", fixed = FALSE)
+    expect_match(txt, "sdl_sint8\\(c\\*c\\)B value out;", fixed = FALSE)
+})
+
 test_that("R headers can be converted despite anonymous CastXML members", {
     skip_if_no_castxml()
 

--- a/tests/testthat/test-rdyncall-compat.R
+++ b/tests/testthat/test-rdyncall-compat.R
@@ -23,14 +23,14 @@ test_that("rdyncall-compatible ABI details are preserved", {
     expect_equal(p$Variadic$value$name, "vf")
     expect_false("unsupported_long_double" %in% p$Function$value$name)
     expect_false("_Hidden" %in% p$Struct$value$name)
-    expect_false("HasAnon" %in% p$Struct$value$name)
+    expect_true("HasAnon" %in% p$Struct$value$name)
     expect_equal(p$Enum$value$values[[which(p$Enum$value$name == "Boolish")]]$name, "PORTER_OK")
 
     report <- port_report(p)
     expect_true(any(report$kind == "unsupported_macro" & report$name == "MACRO_FN"))
     expect_true(any(report$kind == "unsupported_variadic_funcptr" & report$name == "callback_t"))
     expect_true(any(report$kind == "unsupported_signature" & report$name == "unsupported_long_double"))
-    expect_true(any(report$kind == "unsupported_signature" & report$name == "HasAnon"))
+    expect_true(any(report$kind == "unsupported_type" & report$name == "HasAnon"))
     expect_true(any(report$kind == "unsupported_export_name" & report$name == "_Hidden"))
     expect_true(any(report$kind == "unsupported_export_name" & report$name == "TRUE"))
     expect_true(any(report$kind == "unsupported_enum_value" & report$name == "TOO_LOW"))
@@ -43,6 +43,7 @@ test_that("rdyncall-compatible ABI details are preserved", {
     expect_match(txt, "Variadic: vf\\(Z\\)i fmt;", fixed = FALSE)
     expect_match(txt, "Plain\\{i\\[3\\]III\\}a b:5 :0 c:7;", fixed = FALSE)
     expect_match(txt, "PackedAligned\\{cd\\}c d @packed @align\\(8\\);", fixed = FALSE)
+    expect_match(txt, "HasAnon\\{\\};", fixed = FALSE)
 
     validation <- port_validate_symbols(p, c("fixed", "other_symbol"))
     expect_equal(validation$name, c("fixed", "vf"))
@@ -160,6 +161,57 @@ test_that("CastXML bool and signed char fundamental types are supported", {
     expect_match(txt, "sdl_sint8\\(c\\*c\\)B value out;", fixed = FALSE)
 })
 
+test_that("opaque pointer names are preserved without requiring R export names", {
+    skip_if_no_castxml()
+
+    header <- tempfile(fileext = ".h")
+    writeLines(c(
+        "struct _Opaque;",
+        "struct _Opaque *opaque_identity(struct _Opaque *x);",
+        "int opaque_many(struct _Opaque * const *items, const char * const *names);",
+        "struct _Bad { int x; };",
+        "struct _Bad by_value_bad(void);"
+    ), header)
+
+    p <- port(header, limit = TRUE)
+    functions <- port_get(p, "Function")
+
+    expect_true(all(c("opaque_identity", "opaque_many") %in% functions$name))
+    expect_false("by_value_bad" %in% functions$name)
+    expect_true(any(port_report(p, "unsupported_signature")$name == "by_value_bad"))
+
+    p <- port_set(p, Package = "T", Version = "1.0", Library = "T")
+    file <- tempfile(fileext = ".dynport")
+    suppressWarnings(port_write(p, file))
+    txt <- paste(readLines(file), collapse = "\n")
+
+    expect_match(txt, "opaque_identity\\(\\*<_Opaque>\\)\\*<_Opaque> x;", fixed = FALSE)
+    expect_match(txt, "opaque_many\\(pp\\)i items names;", fixed = FALSE)
+})
+
+test_that("limit removes diagnostics from headers outside the selected directories", {
+    skip_if_no_castxml()
+
+    root <- tempfile("porter-limit-root-")
+    outside <- tempfile("porter-limit-outside-")
+    dir.create(root)
+    dir.create(outside)
+
+    outside_header <- file.path(outside, "outside.h")
+    header <- file.path(root, "main.h")
+    writeLines("enum Outside { OUTSIDE_TOO_WIDE = 9223372036854775807ULL };", outside_header)
+    writeLines(c(
+        sprintf("#include \"%s\"", outside_header),
+        "int fixed(void);"
+    ), header)
+
+    p <- port(header, limit = root)
+    expect_false(any(port_report(p)$name == "OUTSIDE_TOO_WIDE"))
+
+    p_all <- port(header, limit = FALSE)
+    expect_true(any(port_report(p_all, "unsupported_enum_value")$name == "OUTSIDE_TOO_WIDE"))
+})
+
 test_that("R headers can be converted despite anonymous CastXML members", {
     skip_if_no_castxml()
 
@@ -192,7 +244,7 @@ test_that("R headers can be converted despite anonymous CastXML members", {
 
     text <- readLines(file, warn = FALSE)
     expect_false(any(grepl("R_allocLD", text, fixed = TRUE)))
-    expect_false(any(grepl("_DllInfo", text, fixed = TRUE)))
+    expect_true(any(grepl("*<_DllInfo>", text, fixed = TRUE)))
     expect_false(any(grepl("FALSE=", text, fixed = TRUE)))
     expect_false(any(grepl("TRUE=", text, fixed = TRUE)))
 


### PR DESCRIPTION
## Summary
Closes #15.

SDL3 exposes many APIs whose CastXML signatures use `bool`, `signed char`, typed opaque pointers, and const-qualified pointer chains. porter was dropping a large part of those APIs even though their ABI can be represented in rdyncall dynport syntax.

## Changes
- Map CastXML `bool` to rdyncall `B`, alongside existing `_Bool`.
- Map CastXML `signed char` to rdyncall `c`, alongside existing `char`.
- Preserve single-level typed opaque pointers such as `*<_SDL_Joystick>` and `*<__sFILE>` even when the pointed-to C tag is not a valid R export name.
- Collapse multi-level pointer and const-qualified pointer chains such as `T * const *` and `const char * const *` to `p` instead of dropping the whole function.
- Keep named aggregates with unsupported member layouts as opaque dynport entries and report them as diagnostics instead of emitting an incorrect layout.
- Filter pre-subset diagnostics through the same `limit` directories so system-header diagnostics do not pollute scoped ports.
- Add regression coverage for SDL-style `bool` / `Sint8`, typed opaque pointer preservation, pointer-chain fallback, by-value invalid aggregate rejection, and scoped diagnostics.

## Out of scope
- Function-like macros and force-inline helpers, such as `SDLNet_Read16`, remain diagnostics rather than generated callable entries.
- APIs hidden behind library-specific compile flags, such as GLPK `GLP_UNDOC`, require the caller to pass the corresponding `cflags`.
- APIs declared in sibling headers, such as libpcap `pcap/namedb.h`, require the input wrapper header to include those headers.
- GLEW still fails in CastXML before porter sees XML because of ambiguous `GLsync` typedef/parameter names in the header; this needs a CastXML/header-specific workaround rather than dynport signature post-processing.