### PR TITLE
fix: write single enum fields separately

### DIFF
--- a/R/write.R
+++ b/R/write.R
@@ -44,7 +44,7 @@ port_write <- function(port, file, reorder = TRUE) {
     )
 
     # treat enums differently
-    if (length(fmt$Enum) == 1L) {
+    if (is.null(names(fmt$Enum))) {
         out_enum <- list(Enum = format_field("Enum", fmt$Enum, show_key = FALSE))
     } else {
         out_enum <- mapply(

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -10,3 +10,23 @@ test_that("port_write() works", {
     readLines
     unlink(f)
 })
+
+test_that("port_write() writes a single enum as Enum/name", {
+    skip_if_no_castxml()
+
+    header <- tempfile(fileext = ".h")
+    writeLines("enum OnlyOne { ONLY_A = 1, ONLY_B = 2 };", header)
+
+    p <- port(header, limit = TRUE)
+    p <- port_set(p, Package = "Test", Version = "1.0", Library = "Test")
+
+    f <- tempfile("porter", fileext = ".dynport")
+    suppressWarnings(port_write(p, f))
+    txt <- readLines(f, warn = FALSE)
+
+    expect_true(any(grepl("^Enum/OnlyOne:", txt)))
+    expect_false(any(grepl("^Enum:", txt)))
+    expect_true(any(grepl("^    ONLY_A=1$", txt)))
+    expect_true(any(grepl("^    ONLY_B=2$", txt)))
+    expect_false(any(grepl("c\\(", txt)))
+})


### PR DESCRIPTION
## Summary
Closes #17.

porter writes multiple enums as separate `Enum/<name>:` DCF fields, which matches rdyncall. With exactly one enum, it instead used a non-empty `Enum:` field and deparsed the enum member vector into a `c(...)` line, so rdyncall rejected the generated dynport.

## Changes
- Treat named enum formatter output as enum definitions regardless of length.
- Keep bare `Enum:` only for the empty enum field case.
- Add regression coverage for a single-enum dynport, including the absence of deparsed `c(...)` output.

## Out of scope
- Changing rdyncall to accept non-empty aggregate `Enum:` fields.
- Changing porter enum member naming or value filtering rules.