### PR TITLE
chore: bump development version after CRAN submission

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,5 @@
 ^LICENSE\.md$
 ^\.github$
 ^\.git$
+^cran-comments\.md$
+^CRAN-SUBMISSION$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,15 @@
 Package: porter
-Title: Generate Port Files for Foreign Function Interface for C Libraries
-Version: 0.0.0.9000
+Title: Generate Port Files for C Libraries
+Version: 0.1.0
 Authors@R: 
-    person("Hongyuan", "Jia", , "hongyuanjia@cqust.edu.cn", role = c("aut", "cre"),
+    person("Hongyuan", "Jia", , "hongyuanjia@cqust.edu.cn", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0002-0075-8183"))
-Description: Generate port files for parsing header files of C libraries using
-    'CastXML'.
+Description: Generate port files for foreign function interfaces to C
+    libraries by parsing C-family header files with 'CastXML'.
 License: MIT + file LICENSE
+URL: https://github.com/hongyuanjia/porter
+BugReports: https://github.com/hongyuanjia/porter/issues
+SystemRequirements: CastXML
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: porter
 Title: Generate Port Files for C Libraries
-Version: 0.1.0
+Version: 0.1.0.9000
 Authors@R: 
     person("Hongyuan", "Jia", , "hongyuanjia@cqust.edu.cn", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0002-0075-8183"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# porter (development version)
+
+* Improve rdyncall-compatible signature output for CastXML `bool`, `signed char`,
+  opaque pointers, and const-qualified pointer chains.
+
+* Write single-enum dynport output as `Enum/<name>:` fields so generated files
+  are accepted by rdyncall.
+
 # porter 0.1.0
 
 * Initial CRAN submission.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,17 @@
+# porter 0.1.0
+
+* Initial CRAN submission.
+
+* Generate rdyncall-compatible dynport files from CastXML output, including
+  functions, variadic functions, function pointer typedefs, enums, structs, and
+  unions.
+
+* Preserve ABI-relevant aggregate details where they can be represented in
+  rdyncall dynport syntax, including fixed arrays, bitfields, packed/aligned
+  layout annotations, and opaque fallbacks with diagnostics.
+
+* Report unsupported function-like macros from CastXML preprocessor output
+  instead of generating callable dynport entries.
+
+* Locate user-installed CastXML executables without downloading or installing
+  external binaries.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,17 @@
+## Test environments
+
+* local macOS Tahoe 26.5.1, R 4.5.3
+* GitHub Actions, ubuntu-latest
+
+## R CMD check results
+
+0 errors | 0 warnings | 2 notes
+
+* This is a new submission.
+* The local macOS check skipped HTML validation because the installed HTML Tidy
+  is not recent enough.
+
+## Reverse dependencies
+
+This is the first CRAN submission of porter. There are no known reverse
+dependencies.


### PR DESCRIPTION
## Summary
After submitting porter 0.1.0 to CRAN from `release/cran-0.1.0`, `main` still carried the old `0.0.0.9000` development metadata. Subsequent fixes were merged into that stale development version, so `main` no longer reflected the CRAN submission baseline.

This PR restores the CRAN release metadata onto current `main` and then uses `usethis::use_dev_version()` to move development to `0.1.0.9000`.

## Changes
- Restore the 0.1.0 release metadata from the CRAN submission branch, including `DESCRIPTION`, `NEWS.md`, `cran-comments.md`, and build ignores for CRAN submission files.
- Bump `DESCRIPTION` from `0.1.0` to `0.1.0.9000` with `usethis::use_dev_version()`.
- Add development NEWS entries for the rdyncall signature compatibility and single-enum dynport fixes that landed after the CRAN submission branch.

## Out of scope
- Changing the already-submitted CRAN 0.1.0 tarball.
- Tagging `v0.1.0`; that should wait until CRAN accepts the submission.
- Including additional functional changes beyond restoring release metadata and opening the next development version.