### PR TITLE
docs: add NEWS PR references

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,13 @@
 # porter (development version)
 
 * Improve rdyncall-compatible signature output for CastXML `bool`, `signed char`,
-  opaque pointers, and const-qualified pointer chains.
+  opaque pointers, and const-qualified pointer chains (#16).
 
 * Write single-enum dynport output as `Enum/<name>:` fields so generated files
-  are accepted by rdyncall.
+  are accepted by rdyncall (#18).
+
+* Preserve object-like macro constants as `Constant` dynport fields and limit
+  `FuncPtr` output to real exported global function pointer variables (#20).
 
 # porter 0.1.0
 


### PR DESCRIPTION
## Summary

Add PR references to current `porter` NEWS entries and include the latest merged dynport constant/function-pointer change.

## Changes

- Add `(#16)` and `(#18)` references to existing development NEWS bullets.
- Add a development NEWS bullet for `Constant` dynport output and `FuncPtr` filtering from #20.
