### PR TITLE
docs(readme): add CRAN installation instructions

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -16,6 +16,7 @@ knitr::opts_chunk$set(
 # porter
 
 <!-- badges: start -->
+[![CRAN status](https://www.r-pkg.org/badges/version/porter)](https://CRAN.R-project.org/package=porter)
 <!-- badges: end -->
 
 The goal of {porter} is to generate port files for [rdyncall](https://github.com/hongyuanjia/rdyncall)
@@ -25,7 +26,13 @@ XML output tool to parse C header files.
 
 ## Installation
 
-You can install the development version of porter like so:
+You can install the released version of porter from CRAN:
+
+``` r
+install.packages("porter")
+```
+
+You can install the development version from GitHub:
 
 ``` r
 remotes::install_github("hongyuanjia/porter")

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 <!-- badges: start -->
 
+[![CRAN
+status](https://www.r-pkg.org/badges/version/porter)](https://CRAN.R-project.org/package=porter)
 <!-- badges: end -->
 
 The goal of {porter} is to generate port files for
@@ -15,7 +17,13 @@ syntax tree XML output tool to parse C header files.
 
 ## Installation
 
-You can install the development version of porter like so:
+You can install the released version of porter from CRAN:
+
+``` r
+install.packages("porter")
+```
+
+You can install the development version from GitHub:
 
 ``` r
 remotes::install_github("hongyuanjia/porter")


### PR DESCRIPTION
## Summary

CRAN now hosts porter 0.1.0, but the README still only documents GitHub development installation. This updates the README so new users see the CRAN release path first.

## Changes

- Add a CRAN status badge pointing to the porter CRAN package page.
- Document `install.packages("porter")` as the released installation path.
- Keep GitHub installation as the development option and regenerate `README.md` from `README.Rmd`.
